### PR TITLE
Fix encoding of UTF-16 surrage pairs and decoding of escaped slashes

### DIFF
--- a/cjson.c
+++ b/cjson.c
@@ -747,8 +747,8 @@ encode_unicode(PyObject *unicode)
         /* Map 21-bit characters to UTF-16 surrogate pairs */
         else if (ch >= 0x10000) {
             unsigned short ucs1, ucs2;
-            ucs1 = ((ch >> 10) & 0x03FF) + 0xD800;
-            ucs2 = (ch & 0x03FF) + 0xDC00;
+            ucs1 = (unsigned short)(((ch - 0x10000) >> 10) & 0x03FF) + 0xD800;
+            ucs2 = (unsigned short)((ch - 0x10000) & 0x03FF) + 0xDC00;
 
             *p++ = '\\';
             *p++ = 'u';

--- a/cjson.c
+++ b/cjson.c
@@ -116,12 +116,13 @@ static PyObject*
 decode_string(JSONData *jsondata)
 {
     PyObject *object;
-    int c, escaping, has_unicode, string_escape;
+    int c, escaping, has_unicode, string_escape, slash_unescape;
     Py_ssize_t len;
     char *ptr;
+    char *lptr;
 
     // look for the closing quote
-    escaping = has_unicode = string_escape = False;
+    escaping = has_unicode = string_escape = slash_unescape = False;
     ptr = jsondata->ptr + 1;
     while (True) {
         c = *ptr;
@@ -153,6 +154,9 @@ decode_string(JSONData *jsondata)
             case '\\':
                 string_escape = True;
                 break;
+            case '/':
+                slash_unescape = True;
+                break;
             }
             escaping = False;
         }
@@ -160,13 +164,40 @@ decode_string(JSONData *jsondata)
     }
 
     len = ptr - jsondata->ptr - 1;
+    lptr = jsondata->ptr+1;
+
+    if (slash_unescape && len < 16384) {
+        char *p = lptr = alloca(len+1);
+        char *wp = p;
+        lptr[len] = 0;
+        memcpy(lptr, jsondata->ptr+1, len);
+        while (*p && *p != '\\') {
+            p++;
+        }
+        wp = p;
+        while (*p) {
+            c = *p++;
+            if (c == '\\') {
+                switch (*p) {
+                case '/':
+                    break;
+                default:
+                    *wp++ = c;
+                }
+            } else {
+                *wp++ = c;
+            }
+        }
+        len = wp - lptr;
+        *wp = 0;
+    }
 
     if (has_unicode || jsondata->all_unicode)
-        object = PyUnicode_DecodeUnicodeEscape(jsondata->ptr+1, len, NULL);
+        object = PyUnicode_DecodeUnicodeEscape(lptr, len, NULL);
     else if (string_escape)
-        object = PyString_DecodeEscape(jsondata->ptr+1, len, NULL, 0, NULL);
+        object = PyString_DecodeEscape(lptr, len, NULL, 0, NULL);
     else
-        object = PyString_FromStringAndSize(jsondata->ptr+1, len);
+        object = PyString_FromStringAndSize(lptr, len);
 
     if (object == NULL) {
         PyObject *type, *value, *tb, *reason;

--- a/cjson.c
+++ b/cjson.c
@@ -697,7 +697,7 @@ encode_unicode(PyObject *unicode)
 
     static const char *hexdigit = "0123456789abcdef";
 #ifdef Py_UNICODE_WIDE
-    const Py_ssize_t expandsize = 10;
+    const Py_ssize_t expandsize = 12;
 #else
     const Py_ssize_t expandsize = 6;
 #endif
@@ -744,46 +744,27 @@ encode_unicode(PyObject *unicode)
         }
 
 #ifdef Py_UNICODE_WIDE
-        /* Map 21-bit characters to '\U00xxxxxx' */
+        /* Map 21-bit characters to UTF-16 surrogate pairs */
         else if (ch >= 0x10000) {
+            unsigned short ucs1, ucs2;
+            ucs1 = ((ch >> 10) & 0x03FF) + 0xD800;
+            ucs2 = (ch & 0x03FF) + 0xDC00;
+            
             *p++ = '\\';
-            *p++ = 'U';
-            *p++ = hexdigit[(ch >> 28) & 0x0000000F];
-            *p++ = hexdigit[(ch >> 24) & 0x0000000F];
-            *p++ = hexdigit[(ch >> 20) & 0x0000000F];
-            *p++ = hexdigit[(ch >> 16) & 0x0000000F];
-            *p++ = hexdigit[(ch >> 12) & 0x0000000F];
-            *p++ = hexdigit[(ch >> 8) & 0x0000000F];
-            *p++ = hexdigit[(ch >> 4) & 0x0000000F];
-            *p++ = hexdigit[ch & 0x0000000F];
+            *p++ = 'u';
+            *p++ = hexdigit[(ucs1 >> 12) & 0x000F];
+            *p++ = hexdigit[(ucs1 >> 8) & 0x000F];
+            *p++ = hexdigit[(ucs1 >> 4) & 0x000F];
+            *p++ = hexdigit[ucs1 & 0x000F];
+            *p++ = '\\';
+            *p++ = 'u';
+            *p++ = hexdigit[(ucs2 >> 12) & 0x000F];
+            *p++ = hexdigit[(ucs2 >> 8) & 0x000F];
+            *p++ = hexdigit[(ucs2 >> 4) & 0x000F];
+            *p++ = hexdigit[ucs2 & 0x000F];
             continue;
         }
 #endif
-        /* Map UTF-16 surrogate pairs to Unicode \UXXXXXXXX escapes */
-        else if (ch >= 0xD800 && ch < 0xDC00) {
-            Py_UNICODE ch2;
-            Py_UCS4 ucs;
-
-            ch2 = *s++;
-            size--;
-            if (ch2 >= 0xDC00 && ch2 <= 0xDFFF) {
-                ucs = (((ch & 0x03FF) << 10) | (ch2 & 0x03FF)) + 0x00010000;
-                *p++ = '\\';
-                *p++ = 'U';
-                *p++ = hexdigit[(ucs >> 28) & 0x0000000F];
-                *p++ = hexdigit[(ucs >> 24) & 0x0000000F];
-                *p++ = hexdigit[(ucs >> 20) & 0x0000000F];
-                *p++ = hexdigit[(ucs >> 16) & 0x0000000F];
-                *p++ = hexdigit[(ucs >> 12) & 0x0000000F];
-                *p++ = hexdigit[(ucs >> 8) & 0x0000000F];
-                *p++ = hexdigit[(ucs >> 4) & 0x0000000F];
-                *p++ = hexdigit[ucs & 0x0000000F];
-                continue;
-            }
-            /* Fall through: isolated surrogates are copied as-is */
-            s--;
-            size++;
-        }
 
         /* Map 16-bit characters to '\uxxxx' */
         if (ch >= 256) {

--- a/cjson.c
+++ b/cjson.c
@@ -749,7 +749,7 @@ encode_unicode(PyObject *unicode)
             unsigned short ucs1, ucs2;
             ucs1 = ((ch >> 10) & 0x03FF) + 0xD800;
             ucs2 = (ch & 0x03FF) + 0xDC00;
-            
+
             *p++ = '\\';
             *p++ = 'u';
             *p++ = hexdigit[(ucs1 >> 12) & 0x000F];

--- a/jsontest.py
+++ b/jsontest.py
@@ -325,9 +325,11 @@ class JsonTest(unittest.TestCase):
         # narrow-but-escaped characters prevents string resizing.
         # Note that u'\U0001D11E\u1234' also breaks, but sometimes goes
         # undetected.
+        # In any case, in ECMA-404, only utf-16 surrogate pairs are
+        # valid, so \U0001D11E should be encoded as \ud834\udd1e
         s = cjson.encode(u'\U0001D11E\U0001D11E\U0001D11E\U0001D11E'
                          u'\u1234\u1234\u1234\u1234\u1234\u1234')
-        self.assertEqual(r'"\U0001d11e\U0001d11e\U0001d11e\U0001d11e'
+        self.assertEqual(r'"\ud834\udd1e\ud834\udd1e\ud834\udd1e\ud834\udd1e'
                          r'\u1234\u1234\u1234\u1234\u1234\u1234"', s)
         
 def main():


### PR DESCRIPTION
UCS4 escape sequences aren't valid JSON, so when Py_UNICODE_WIDE
is defined, UTF-16 surrogate pairs need to be produced.

Decoding retains the surrogate pairs as separate code points
instead of joining them, something that perhaps should be
improved, but isn't invalid (just inconvenient)

The escape code `\/` in the JSON spec means `/`, but it was not being
properly decoded (python's own escaping doesn't behave like this,
so one cannot rely on python's unescaping to handle it)
